### PR TITLE
Fixed a date format

### DIFF
--- a/langate/helpdesk/templates/ticket_detail.html
+++ b/langate/helpdesk/templates/ticket_detail.html
@@ -16,7 +16,7 @@
         {% for message in messages %}
         <div class="text-center">
             <p class="mb-1">{{message}}</p>
-            <small class="text-muted">{{message.sender}} - ({{message.date|date:"l - H:m"}})</small>
+            <small class="text-muted">{{message.sender}} - ({{message.date|date:"l - H:i"}})</small>
         </div>
         {% endfor %}
 


### PR DESCRIPTION
m formatter is for month, minutes use i

Cf https://docs.djangoproject.com/fr/2.2/ref/templates/builtins/#date